### PR TITLE
Fix removing event listener from removed dom node

### DIFF
--- a/src/js/lib/scrollspy.js
+++ b/src/js/lib/scrollspy.js
@@ -225,7 +225,7 @@ export default class Scrollspy extends React.Component {
   offEvent() {
     const el = this.props.rootEl ? document.querySelector(this.props.rootEl) : window
 
-    el.removeEventListener('scroll', this._handleSpy)
+    el && el.removeEventListener('scroll', this._handleSpy)
   }
 
   onEvent() {


### PR DESCRIPTION
If a react component is unmounting and the dom node does not exist anymore an error is raised. We don't have to remove listeners from nodes that are removed as the browser handles this logic.